### PR TITLE
Add ability to pass custom args to imagemagick

### DIFF
--- a/lib/papercut.coffee
+++ b/lib/papercut.coffee
@@ -8,7 +8,8 @@ config = {
   extension: 'jpg'
   process: 'resize'
   directory: '.'
-  quality: 1
+  quality: 1,
+  custom: []
 }
 
 module.exports = papercut =

--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -70,6 +70,7 @@ module.exports = class Processor
   process: (method, name, path, version, callback)->
     size = @getSize(version.size)
     params =
+      customArgs: version.custom or @config.custom
       srcPath: path
       width: size.width
       height: size.height


### PR DESCRIPTION
Hi, 

This is a great module. I started writing my own before finding this and was really pleased that papercut just works straight out of the box.

The only issue I had was in handling uploads from IOS.  Imagemagick was not rotating the image based on the exif information in the uploaded file.

I just added the ability to pass custom arguments to paperclip through the version object like so:

```
@version
  custom: ['-auto-orient']
```

I figured it would be more flexible to add this than to add a custom flag just for what I wanted.

Thanks for the good work.
