### PR TITLE
Removed ImageMagick and replaced it with GraphicsMagick

### DIFF
--- a/lib/papercut.coffee
+++ b/lib/papercut.coffee
@@ -8,7 +8,7 @@ config = {
   extension: 'jpg'
   process: 'resize'
   directory: '.'
-  quality: 1,
+  quality: 90,
   custom: []
 }
 

--- a/lib/papercut.coffee
+++ b/lib/papercut.coffee
@@ -146,8 +146,8 @@ module.exports = papercut =
         errors = []
         async.forEach @versions, (version, done)=>
           method = version.process or @config.process
-          @processor[method] name, path, version, (err, stdout, stderr)=>
+          @processor[method] name, path, version, (err, buffer)=>
             return done(err) if err?
-            @store.save(name, version, stdout, stderr, done)
+            @store.save(name, version, buffer, done)
         , (err)=>
           callback(err, @store.result)

--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -1,8 +1,8 @@
 fs = require('fs')
-im = require('gm')
+gm = require('gm')
 
 ###
-Process call node-graphicksmagick module to process images
+Process call node-graphicsmagick module to process images
 and return file stream to callback
 ###
 
@@ -16,7 +16,7 @@ module.exports = class Processor
     width: s[0], height: s[1]
 
   ###
-  Resize and crop image using node-imagemagic's crop method
+  Resize and crop image using node-graphicsmagick's crop method
 
   @param {String} name
   @param {String} path
@@ -59,7 +59,7 @@ module.exports = class Processor
 
   ###
   Process image with methods,
-  build params and call node-imagemagick's method
+  build params and call node-graphicsmagick's method
 
   @param {String} method
   @param {String} name
@@ -71,11 +71,11 @@ module.exports = class Processor
   ###
   process: (method, name, path, version, callback)->
     size = @getSize(version.size)
-    gmi = @gm(path);
+    gmi = @gm(path)
     format = version.extension or @config.extension
-    if name is "resize"
+    if method is "resize"
       gmi.resize size.width, size.height
-    if name is "crop"
+    if method is "crop"
       gmi.crop size.width, size.height, 0, 0
     gmi.quality version.quality or @config.quality
     gmi.toBuffer format, callback

--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -71,12 +71,11 @@ module.exports = class Processor
   ###
   process: (method, name, path, version, callback)->
     size = @getSize(version.size)
-    params =
-      srcPath: path
-      width: size.width
-      height: size.height
-      format: version.extension or @config.extension
-      quality: version.quality or @config.quality
-      customArgs: version.custom or @config.custom
-
-    @im[method] params, callback
+    gmi = @gm(path);
+    output = name + "." + (version.extension or @config.extension)
+    if name is "resize"
+      gmi.resize size.width, size.height
+    if name is "crop"
+      gmi.crop size.width, size.height, 0, 0
+    gmi.quality version.quality or @config.quality
+    gmi.write output, callback

--- a/lib/processor.coffee
+++ b/lib/processor.coffee
@@ -1,13 +1,13 @@
 fs = require('fs')
-im = require('imagemagick')
+im = require('gm')
 
 ###
-Process call node-imagemagick module to process images
+Process call node-graphicksmagick module to process images
 and return file stream to callback
 ###
 
 module.exports = class Processor
-  im: im
+  gm: gm
 
   constructor: (@config)->
 
@@ -72,10 +72,10 @@ module.exports = class Processor
   process: (method, name, path, version, callback)->
     size = @getSize(version.size)
     gmi = @gm(path);
-    output = name + "." + (version.extension or @config.extension)
+    format = version.extension or @config.extension
     if name is "resize"
       gmi.resize size.width, size.height
     if name is "crop"
       gmi.crop size.width, size.height, 0, 0
     gmi.quality version.quality or @config.quality
-    gmi.write output, callback
+    gmi.toBuffer format, callback

--- a/lib/store.coffee
+++ b/lib/store.coffee
@@ -47,7 +47,7 @@ exports.FileStore = class FileStore
     @result[version.name] = @getUrlPath(name, version)
 
     fs.writeFile @getDstPath(name, version), buffer, 'binary', (err, file)=>
-      callback(err, @result[version.name])
+        callback(err, @result[version.name])
 
 ###
 Upload file to Amazon S3 and return the url of file

--- a/lib/store.coffee
+++ b/lib/store.coffee
@@ -37,18 +37,16 @@ exports.FileStore = class FileStore
 
   @param {String} name
   @param {Object} version
-  @param {Object} stdout stream
-  @param {Object} stderr stream
+  @param {Object} buffer stream
   @param {Function} callback
 
   @api public
   ###
-  save: (name, version, stdout, stderr, callback)=>
-    return callback(new Error(stderr)) if stderr? and stderr.length isnt 0
+  save: (name, version, buffer, callback)=>
 
     @result[version.name] = @getUrlPath(name, version)
 
-    fs.writeFile @getDstPath(name, version), stdout, 'binary', (err, file)=>
+    fs.writeFile @getDstPath(name, version), buffer, 'binary', (err, file)=>
       callback(err, @result[version.name])
 
 ###
@@ -95,16 +93,13 @@ exports.S3Store = class S3Store
 
   @param {String} name
   @param {Object} version
-  @param {Object} stdout stream
-  @param {Object} stderr stream
+  @param {Object} buffer stream
   @param {Function} callback
 
   @api public
   ###
-  save: (name, version, stdout, stderr, callback)=>
-    return callback(new Error(stderr)) if stderr? and stderr.length isnt 0
-
-    buffer = new Buffer(stdout, 'binary')
+  save: (name, version, buffer, callback)=>
+    buffer = new Buffer(buffer, 'binary')
     dstPath = @getDstPath name, version
 
     @headers['Content-Length'] = buffer.length
@@ -125,6 +120,6 @@ exports.TestStore = class TestStore
   getDstPath: (name, version)->
     "#{name}-#{version.name}.#{@config.extension}"
 
-  save: (name, version, stdout, stderr, callback)=>
+  save: (name, version, buffer, callback)=>
     @result[version.name] = @getUrlPath(name, version)
     callback(null, @result[version.name])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papercut",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Papercut is a node package to handle image upload, resize and sync with Amazon s3",
   "main": "index.js",
   "keywords": ["imagemagick", "image", "process", "s3"],
@@ -10,7 +10,7 @@
   "repository": "",
   "dependencies": {
     "coffee-script": "1.4.x",
-    "imagemagick": "git://github.com/rsms/node-imagemagick.git",
+    "gm": "x",
     "knox": "0.8.x",
     "async": "0.1.x"
   },


### PR DESCRIPTION
I loved the format and performance of papercut, but was experiencing the following issues:
- When processing dozens of images the thread pool would run out and the program would crash
- About one in ten images would fail due to some bug in ImageMagick
- Occasionally things would slow to a crawl for not apparent reason

When looking into the issues I found numerous people experiencing similar thing in bug reports gone unanswered. The current state of the node ImageMagick plugin is unsupported and unmaintained and the ImageMagick library as a whole seems to have fallen behind. 

As such I proceeded to port papercut over to GraphicsMagick using the plugin 'gm'. Feel free to close this request if it doesn't align with your vision, I just figured I would share seeing as it performs with significantly less errors and headaches. 

Thanks.
