### PR TITLE
Fix "process copy" not work in express example

### DIFF
--- a/examples/express.coffee
+++ b/examples/express.coffee
@@ -21,6 +21,10 @@ AvatarUploader = papercut.Schema (schema)->
   @version
     name: 'avatar'
     size: '200x200'
+  
+  @version
+    name: 'origin'
+    process: 'copy'
 
 express = require('express')
 app = express()
@@ -48,8 +52,10 @@ imageId = 0
 
 app.post '/avatar', (req, res)->
   uploader = new AvatarUploader()
+  timeStamp = new Date()
+  timeStamp = timeStamp.getTime()
 
-  uploader.process "#{imageId++}", req.files.avatar.path, (err, images)->
+  uploader.process "#{timeStamp}_#{req.files.avatar.name}", req.files.avatar.path, (err, images)->
     res.send 200, """
       <html>
         <head>

--- a/examples/express.coffee
+++ b/examples/express.coffee
@@ -48,8 +48,10 @@ imageId = 0
 
 app.post '/avatar', (req, res)->
   uploader = new AvatarUploader()
+  timeStamp = new Date()
+  timeStamp = timeStamp.getTime()
 
-  uploader.process "#{imageId++}", req.files.avatar.path, (err, images)->
+  uploader.process "#{timeStamp}_#{req.files.avatar.name}", req.files.avatar.path, (err, images)->
     res.send 200, """
       <html>
         <head>


### PR DESCRIPTION
The copy propcess will not work because  papercut checks and compares file extension:

<pre>
 copy: (name, path, version, callback)->
   # if using imageId++, 'name' variable does not have file extension 
    if name.indexOf @config.extension isnt -1
      fs.readFile path, 'binary', callback
    else
      callback(new Error("file extension is not #{@config.extension}"))
</pre>
