### PR TITLE
ACL can now be specified in config

### DIFF
--- a/lib/papercut.coffee
+++ b/lib/papercut.coffee
@@ -9,7 +9,8 @@ config = {
   process: 'resize'
   directory: '.'
   quality: 1,
-  custom: []
+  custom: [],
+  acl: 'public-read'
 }
 
 module.exports = papercut =

--- a/lib/store.coffee
+++ b/lib/store.coffee
@@ -66,7 +66,7 @@ exports.S3Store = class S3Store
       bucket: config.bucket
     @headers =
       'Content-Type': "image/#{@config.extension}"
-      'x-amz-acl': 'public-read'
+      'x-amz-acl': "#{@config.acl}"
 
   ###
   Get relative file path on S3


### PR DESCRIPTION
Currently all uploads are set to public-read.

This commit allows for uploading with different ACL.

Defaults to public-read.
